### PR TITLE
Update osinfo_win.nim

### DIFF
--- a/src/osinfo_win.nim
+++ b/src/osinfo_win.nim
@@ -35,7 +35,7 @@ type
     dwPageSize*: int32
     lpMinimumApplicationAddress*: pointer
     lpMaximumApplicationAddress*: pointer
-    dwActiveProcessorMask*: int32
+    dwActiveProcessorMask*: ptr int32
     dwNumberOfProcessors*: int32
     dwProcessorType*: int32
     dwAllocationGranularity*: int32


### PR DESCRIPTION
See https://github.com/Araq/Nim/issues/2161 . It essentially just fixes a mistake that's also in MinGW. The structure according to Microsoft uses a `DWORD_PTR`, which is going to have a different size on 64-bit systems.