### PR TITLE
Check OS at compile time

### DIFF
--- a/src/osinfo/posix.nim
+++ b/src/osinfo/posix.nim
@@ -1,10 +1,14 @@
 # Copyright (C) Dominik Picheta. All rights reserved.
 # MIT License. Look at license.txt for more info.
+
+when not defined(posix):
+  {.error: "This module is only supported on POSIX".}
+
 import "$nim/lib/posix/posix", strutils, os
 
 when false:
   type
-    Tstatfs {.importc: "struct statfs64", 
+    Tstatfs {.importc: "struct statfs64",
               header: "<sys/statfs.h>", final, pure.} = object
       f_type: int
       f_bsize: int
@@ -22,12 +26,12 @@ when false:
 
 proc getSystemVersion*(): string =
   result = ""
-  
+
   var unix_info: Utsname
-  
+
   if uname(unix_info) != 0:
     os.raiseOSError(osLastError())
-  
+
   if $unix_info.sysname == "Linux":
     # Linux
     result.add("Linux ")
@@ -67,8 +71,7 @@ proc getSystemVersion*(): string =
       result.add("Unknown version")
   else:
     result.add($unix_info.sysname & " " & $unix_info.release)
-    
-    
+
 when isMainModule:
   var unix_info: Utsname
   echo(uname(unix_info))
@@ -81,4 +84,4 @@ when isMainModule:
   # var stfs: TStatfs
   # echo(statfs("sysinfo_posix.nim", stfs))
   # echo(stfs.f_files)
-  
+

--- a/src/osinfo/win.nim
+++ b/src/osinfo/win.nim
@@ -3,8 +3,8 @@
 
 ## This module implements procedures which return various information about
 ## the user's computer.
-##
-## **Note:** This module will only work on Windows.
+when not defined(windows):
+  {.error: "This module is only supported on Windows".}
 
 import winlean
 
@@ -22,7 +22,7 @@ type
     ullTotalVirtual: int64
     ullAvailVirtual: int64
     ullAvailExtendedVirtual: int64
-    
+
   SYSTEM_INFO* {.final, pure.} = object
     wProcessorArchitecture*: int16
     wReserved*: int16
@@ -43,12 +43,12 @@ type
     MemoryLoad*: int ## occupied memory, in percent
     TotalPhysMem*: int64 ## Total Physical memory, in bytes
     AvailablePhysMem*: int64 ## Available physical memory, in bytes
-    TotalPageFile*: int64 ## The current committed memory limit 
+    TotalPageFile*: int64 ## The current committed memory limit
                           ## for the system or the current process, whichever is smaller, in bytes.
     AvailablePageFile*: int64 ## The maximum amount of memory the current process can commit, in bytes.
     TotalVirtualMem*: int64 ## Total virtual memory, in bytes
     AvailableVirtualMem*: int64 ## Available virtual memory, in bytes
-    
+
   TOSVERSIONINFOEX {.final, pure.} = object
     dwOSVersionInfoSize: int32
     dwMajorVersion: int32
@@ -61,7 +61,7 @@ type
     wSuiteMask: int16
     wProductType: int8
     wReserved: char
-    
+
   TVersionInfo* = object
     majorVersion*: int
     minorVersion*: int
@@ -72,7 +72,7 @@ type
     SPMinor*: int ## Minor service pack version
     SuiteMask*: int
     ProductType*: int
-    
+
   TPartitionInfo* = tuple[FreeSpace, TotalSpace: FileTime]
 
 const
@@ -95,9 +95,9 @@ const
   VER_NT_DOMAIN_CONTROLLER* = 0x0000002
   VER_NT_SERVER* = 0x0000003
   VER_NT_WORKSTATION* = 0x0000001
-  
+
   VER_PLATFORM_WIN32_NT* = 2
-  
+
   # Product Info - getProductInfo() - (Remove unused ones ?)
   PRODUCT_BUSINESS* = 0x00000006
   PRODUCT_BUSINESS_N* = 0x00000010
@@ -148,18 +148,18 @@ const
   PRODUCT_ULTIMATE_N* = 0x0000001C
   PRODUCT_WEB_SERVER* = 0x00000011
   PRODUCT_WEB_SERVER_CORE* = 0x0000001D
-  
+
   PROCESSOR_ARCHITECTURE_AMD64* = 9 ## x64 (AMD or Intel)
   PROCESSOR_ARCHITECTURE_IA64* = 6 ## Intel Itanium Processor Family (IPF)
   PROCESSOR_ARCHITECTURE_INTEL* = 0 ## x86
   PROCESSOR_ARCHITECTURE_UNKNOWN* = 0xffff ## Unknown architecture.
-  
+
   # GetSystemMetrics
-  SM_SERVERR2 = 89 
-  
+  SM_SERVERR2 = 89
+
 proc globalMemoryStatusEx*(lpBuffer: var TMEMORYSTATUSEX){.stdcall, dynlib: "kernel32",
     importc: "GlobalMemoryStatusEx".}
-    
+
 proc getMemoryInfo*(): TMemoryInfo =
   ## Retrieves memory info
   var statex: TMEMORYSTATUSEX
@@ -198,13 +198,13 @@ proc getVersionInfo*(): TVersionInfo =
   result.SuiteMask = osvi.wSuiteMask
   result.ProductType = osvi.wProductType
 
-proc getProductInfo*(majorVersion, minorVersion, SPMajorVersion, 
+proc getProductInfo*(majorVersion, minorVersion, SPMajorVersion,
                      SPMinorVersion: int): int =
   ## Retrieves Windows' ProductInfo, this function only works in Vista and 7
-  var pGPI = cast[proc (dwOSMajorVersion, dwOSMinorVersion, 
+  let pGPI = cast[proc (dwOSMajorVersion, dwOSMinorVersion,
               dwSpMajorVersion, dwSpMinorVersion: int32, outValue: Pint32){.stdcall.}](getProcAddress(
                 getModuleHandleA("kernel32.dll"), "GetProductInfo"))
-                
+
   if pGPI != nil:
     var dwType: int32
     pGPI(int32(majorVersion), int32(minorVersion), int32(SPMajorVersion), int32(SPMinorVersion), addr(dwType))
@@ -214,15 +214,15 @@ proc getProductInfo*(majorVersion, minorVersion, SPMajorVersion,
 
 proc getSystemInfo*(lpSystemInfo: LPSYSTEM_INFO){.stdcall, dynlib: "kernel32",
     importc: "GetSystemInfo".}
-    
+
 proc getSystemInfo*(): TSYSTEM_INFO =
   ## Returns the SystemInfo
 
   # Use GetNativeSystemInfo if it's available
   var pGNSI = cast[proc (lpSystemInfo: LPSYSTEM_INFO){.stdcall.}](getProcAddress(
                 getModuleHandleA("kernel32.dll"), "GetNativeSystemInfo"))
-                
-  var systemi: TSYSTEM_INFO              
+
+  var systemi: TSYSTEM_INFO
   if pGNSI != nil:
     pGNSI(addr(systemi))
   else:
@@ -235,15 +235,14 @@ proc getSystemMetrics*(nIndex: int32): int32{.stdcall, dynlib: "user32",
 
 proc `$`*(osvi: TVersionInfo): string =
   ## Turns a VersionInfo object into a string
-
   if osvi.platformID == VER_PLATFORM_WIN32_NT and osvi.majorVersion > 4:
     result = "Microsoft "
-    
-    var si = getSystemInfo()
+
+    let si = getSystemInfo()
     # Test for the specific product
     if osvi.majorVersion == 10:
       if osvi.ProductType == VER_NT_WORKSTATION:
-        result.add("Windows 10")
+        result.add("Windows 10 ")
       else: result.add("Windows Server 2016")
 
     if osvi.majorVersion == 6:
@@ -264,7 +263,7 @@ proc `$`*(osvi: TVersionInfo): string =
           result.add("Windows 8.1 ")
         else: result.add("Windows Server 2012 R2 ")
 
-      var dwType = getProductInfo(osvi.majorVersion, osvi.minorVersion, 0, 0)
+      let dwType = getProductInfo(osvi.majorVersion, osvi.minorVersion, 0, 0)
       case dwType
       of PRODUCT_ULTIMATE:
         result.add("Ultimate Edition")
@@ -311,12 +310,12 @@ proc `$`*(osvi: TVersionInfo): string =
         result.add("Windows Storage Server 2003")
       elif (osvi.SuiteMask and VER_SUITE_WH_SERVER) != 0:
         result.add("Windows Home Server")
-      elif osvi.ProductType == VER_NT_WORKSTATION and 
+      elif osvi.ProductType == VER_NT_WORKSTATION and
           si.wProcessorArchitecture==PROCESSOR_ARCHITECTURE_AMD64:
         result.add("Windows XP Professional x64 Edition")
       else:
         result.add("Windows Server 2003, ")
-      
+
       # Test for the specific product
       if osvi.ProductType != VER_NT_WORKSTATION:
         if ze(si.wProcessorArchitecture) == PROCESSOR_ARCHITECTURE_IA64:
@@ -343,7 +342,7 @@ proc `$`*(osvi: TVersionInfo): string =
           else:
             result.add("Standard Edition")
     # End of 5.2
-    
+
     if osvi.majorVersion == 5 and osvi.minorVersion == 1:
       result.add("Windows XP ")
       if (osvi.SuiteMask and VER_SUITE_PERSONAL) != 0:
@@ -351,7 +350,7 @@ proc `$`*(osvi: TVersionInfo): string =
       else:
         result.add("Professional")
     # End of 5.1
-    
+
     if osvi.majorVersion == 5 and osvi.minorVersion == 0:
       result.add("Windows 2000 ")
       if osvi.ProductType == VER_NT_WORKSTATION:
@@ -364,24 +363,22 @@ proc `$`*(osvi: TVersionInfo): string =
         else:
           result.add("Server")
     # End of 5.0
-    
+
     # Include service pack (if any) and build number.
     if len(osvi.SPVersion) > 0:
       result.add(" ")
       result.add(osvi.SPVersion)
-    
+
     result.add(" (build " & $osvi.buildNumber & ")")
-    
+
     if osvi.majorVersion >= 6:
       if ze(si.wProcessorArchitecture) == PROCESSOR_ARCHITECTURE_AMD64:
         result.add(", 64-bit")
       elif ze(si.wProcessorArchitecture) == PROCESSOR_ARCHITECTURE_INTEL:
         result.add(", 32-bit")
-    
   else:
     # Windows 98 etc...
     result = "Unknown version of windows[Kernel version <= 4]"
-    
 
 proc getFileSize*(file: string): BiggestInt =
   ## Retrieves the size of the specified file.
@@ -389,13 +386,13 @@ proc getFileSize*(file: string): BiggestInt =
 
   when useWinUnicode:
     var aa = newWideCString(file)
-    var hFile = findFirstFileW(aa, fileData)
+    let hFile = findFirstFileW(aa, fileData)
   else:
-    var hFile = findFirstFileA(file, fileData)
-  
+    let hFile = findFirstFileA(file, fileData)
+
   if hFile == INVALID_HANDLE_VALUE:
     raise newException(IOError, $getLastError())
-  
+
   return fileData.nFileSizeLow
 
 proc getDiskFreeSpaceEx*(lpDirectoryName: cstring, lpFreeBytesAvailableToCaller,
@@ -406,18 +403,18 @@ proc getDiskFreeSpaceEx*(lpDirectoryName: cstring, lpFreeBytesAvailableToCaller,
 proc getPartitionInfo*(partition: string): TPartitionInfo =
   ## Retrieves partition info, for example ``partition`` may be ``"C:\"``
   var freeBytes, totalBytes, totalFreeBytes: FileTime
-  discard getDiskFreeSpaceEx(partition, freeBytes, totalBytes, 
+  discard getDiskFreeSpaceEx(partition, freeBytes, totalBytes,
                                totalFreeBytes)
   return (freeBytes, totalBytes)
 
 when isMainModule:
-  var r = getMemoryInfo()
+  let r = getMemoryInfo()
   echo("Memory load: ", r.MemoryLoad, "%")
-  
-  var osvi = getVersionInfo()
-  
+
+  let osvi = getVersionInfo()
+
   echo($osvi)
 
   #echo(getFileSize(r"lib\impure\osinfo_win.nim") div 1024, " KB")
-  
+
   echo(rdFileTime(getPartitionInfo(r"C:\")[0]))


### PR DESCRIPTION
The current code simply has a note at the top of the `win` module of `**Note:** This module will only work on Windows`. This patch checks the OS and uses the `{.error.}` pragma if the OS doesn't match.

It also changes some uses of `var` to `let` where it makes sense to do so.

The removal of the extra whitespace was done by my editor and can largely be ignored.